### PR TITLE
Increase max JSON file size for contract verification

### DIFF
--- a/ui/contractVerification/fields/ContractVerificationFieldSources.tsx
+++ b/ui/contractVerification/fields/ContractVerificationFieldSources.tsx
@@ -139,8 +139,8 @@ const ContractVerificationFieldSources = ({ fileTypes, multiple, required, title
 
   const validateFileSize = React.useCallback(async(value: FieldPathValue<FormFields, typeof name>): Promise<ValidateResult> => {
     if (Array.isArray(value)) {
-      const FILE_SIZE_LIMIT = 20 * Mb;
-      const errors = value.map(({ size }) => size > FILE_SIZE_LIMIT ? 'File is too big. Maximum size is 20 Mb.' : '');
+      const FILE_SIZE_LIMIT = 50 * Mb;
+      const errors = value.map(({ size }) => size > FILE_SIZE_LIMIT ? 'File is too big. Maximum size is 50 Mb.' : '');
       if (errors.some((item) => item !== '')) {
         return errors.join(';');
       }


### PR DESCRIPTION
## Description and Related Issue(s)

The maximum JSON file size to upload when trying to verify a contract is hardcoded to 20 MBytes. In some cases, this limit is hit and the contracts cannot be verified, as reported by @max-sanchez a few days ago in re the BTC vault contracts.

### Proposed Changes

Increase the hardcoded value to 50 MBytes. That should be enough for now.

### Additional Information

In the future, this could be configured through an environment variable. Probably the better way to do so is to add the variable in the `configs/app` structure.