### PR TITLE
Set default USD accuracy to 2

### DIFF
--- a/ui/shared/CurrencyValue.tsx
+++ b/ui/shared/CurrencyValue.tsx
@@ -14,7 +14,7 @@ interface Props {
   isLoading?: boolean;
 }
 
-const CurrencyValue = ({ value, currency = '', decimals, exchangeRate, className, accuracy, accuracyUsd, isLoading }: Props) => {
+const CurrencyValue = ({ value, currency = '', decimals, exchangeRate, className, accuracy, accuracyUsd = 2, isLoading }: Props) => {
   if (isLoading) {
     return (
       <Skeleton className={ className } display="inline-block">0.00 ($0.00)</Skeleton>


### PR DESCRIPTION
## Description and Related Issue(s)

After enabling the USD prices in the explorer, we saw the USD values have many more decimals than what is commonly used for fiat values.

### Proposed Changes

Set a default of two decimals in the component that renders the USD values.

### Additional Information

Before:

<img width="852" alt="image" src="https://github.com/user-attachments/assets/e1f99152-6cc1-4027-a7b0-593e97fcbaff" />

After:

<img width="687" alt="image" src="https://github.com/user-attachments/assets/60941c99-57e9-4e84-9412-fea4f31b5a01" />

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
